### PR TITLE
Better approach for preparing the test database

### DIFF
--- a/src/test/java/com/marklogic/mule/extension/AbstractFlowTester.java
+++ b/src/test/java/com/marklogic/mule/extension/AbstractFlowTester.java
@@ -16,19 +16,9 @@ public abstract class AbstractFlowTester extends MuleArtifactFunctionalTestCase 
     protected final static String TEXT_HELLO_WORLD = "Hello, World!\n";
     protected final static String XML_HELLO_WORLD = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Hello>World</Hello>";
 
-
-    // Use this to delete all non-test-data documents (i.e. anything not loaded by the test-app) at the start
-    // of a test.
-    protected final static String DELETE_QUERY = "declareUpdate();\n" +
-        "for (var uri of cts.uris(null, null, cts.notQuery(cts.collectionQuery('test-data')))) {\n" +
-        "  xdmp.documentDelete(uri);\n" +
-        "}";
-
     Message runFlowGetMessage(String flowName) {
         try {
-            return flowRunner(flowName)
-                .withVariable("DELETE_QUERY", DELETE_QUERY)
-                .keepStreamsOpen().run().getMessage();
+            return flowRunner(flowName).keepStreamsOpen().run().getMessage();
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/src/test/resources/eval-javascript.xml
+++ b/src/test/resources/eval-javascript.xml
@@ -13,6 +13,9 @@
         authenticationType="DIGEST"/>
   </marklogic:config>
 
+  <flow name="prepare-database">
+    <marklogic:search-documents config-ref="config" collection="dummy" restTransform="prepare-database"/>
+  </flow>
 
   <flow name="simple-math">
     <marklogic:eval-javascript config-ref="config">
@@ -21,9 +24,7 @@
   </flow>
 
   <flow name="writeAndDeleteDocument">
-    <marklogic:eval-javascript config-ref="config">
-      <marklogic:script><![CDATA[#[vars.DELETE_QUERY]]]></marklogic:script>
-    </marklogic:eval-javascript>
+    <flow-ref name="prepare-database"/>
     <marklogic:read-document config-ref="config" uri="/metadataSamples/json/hello.json"/>
     <marklogic:write-document config-ref="config" uriPrefix='/toBeDeleted' uriSuffix=".json" generateUUID="False"
                           permissions="rest-reader,read,rest-reader,update"/>

--- a/src/test/resources/read-and-write-document.xml
+++ b/src/test/resources/read-and-write-document.xml
@@ -15,11 +15,12 @@
         authenticationType="DIGEST"/>
   </marklogic:config>
 
-  <flow name="read-and-write-document">
+  <flow name="prepare-database">
+    <marklogic:search-documents config-ref="config" collection="dummy" restTransform="prepare-database"/>
+  </flow>
 
-    <marklogic:eval-javascript config-ref="config">
-      <marklogic:script><![CDATA[#[vars.DELETE_QUERY]]]></marklogic:script>
-    </marklogic:eval-javascript>
+  <flow name="read-and-write-document">
+    <flow-ref name="prepare-database"/>
     <marklogic:read-document config-ref="config" uri="/metadataSamples/json/hello.json"/>
     <marklogic:write-document config-ref="config" uriPrefix='#["/test" ++ attributes.uri]' generateUUID="False"
                           permissions="rest-reader,read,rest-reader,update"/>

--- a/src/test/resources/write-document.xml
+++ b/src/test/resources/write-document.xml
@@ -13,8 +13,12 @@
         authenticationType="DIGEST"/>
   </marklogic:config>
 
+  <flow name="prepare-database">
+    <marklogic:search-documents config-ref="config" collection="dummy" restTransform="prepare-database"/>
+  </flow>
+
   <flow name="writeTextDocumentWithAllMetadata">
-    <marklogic:delete-collection config-ref="config" collection="writeTextDocumentWithAllMetadata"/>
+    <flow-ref name="prepare-database"/>
     <marklogic:read-document config-ref="config" uri="/metadataSamples/text/hello.text"/>
     <marklogic:write-document config-ref="config" uriPrefix="/writeTextDocumentWithAllMetadata/hello" uriSuffix=".txt"
                           format="UNKNOWN" generateUUID="False"
@@ -24,7 +28,7 @@
   </flow>
 
   <flow name="writeJsonDocumentWithAllMetadata">
-    <marklogic:delete-collection config-ref="config" collection="writeJsonDocumentWithAllMetadata"/>
+    <flow-ref name="prepare-database"/>
     <marklogic:read-document config-ref="config" uri="/metadataSamples/json/hello.json"/>
     <marklogic:write-document config-ref="config" uriPrefix="/writeJsonDocumentWithAllMetadata/hello" uriSuffix=".json"
                           format="JSON" generateUUID="False"
@@ -34,7 +38,7 @@
   </flow>
 
   <flow name="writeXmlDocumentWithAllMetadata">
-    <marklogic:delete-collection config-ref="config" collection="writeXmlDocumentWithAllMetadata"/>
+    <flow-ref name="prepare-database"/>
     <marklogic:read-document config-ref="config" uri="/metadataSamples/xml/hello.xml"/>
     <marklogic:write-document config-ref="config" uriPrefix="/writeXmlDocumentWithAllMetadata/hello" uriSuffix=".xml"
                           format="XML" generateUUID="False"
@@ -44,7 +48,7 @@
   </flow>
 
   <flow name="writeBinaryDocumentWithAllMetadata">
-    <marklogic:delete-collection config-ref="config" collection="writeBinaryDocumentWithAllMetadata"/>
+    <flow-ref name="prepare-database"/>
     <marklogic:read-document config-ref="config" uri="/metadataSamples/binary/logo.png"/>
     <marklogic:write-document config-ref="config" uriPrefix="/writeBinaryDocumentWithAllMetadata/logo" uriSuffix=".png"
                           format="BINARY" generateUUID="False"
@@ -54,7 +58,7 @@
   </flow>
 
   <flow name="writeDocumentWithoutUriWithTextFormat">
-    <marklogic:delete-collection config-ref="config" collection="writeDocumentWithoutUriWithTextFormat"/>
+    <flow-ref name="prepare-database"/>
     <marklogic:read-document config-ref="config" uri="/metadataSamples/text/hello.text"/>
     <marklogic:write-document config-ref="config" format="TEXT" permissions="rest-reader,read,rest-reader,update"
                           quality="5" collections="writeDocumentWithoutUriWithTextFormat"/>
@@ -63,7 +67,7 @@
   </flow>
 
   <flow name="writeDocumentWithoutUriWithoutFormat">
-    <marklogic:delete-collection config-ref="config" collection="writeDocumentWithoutUriWithoutFormat"/>
+    <flow-ref name="prepare-database"/>
     <marklogic:read-document config-ref="config" uri="/metadataSamples/text/hello.text"/>
     <marklogic:write-document config-ref="config" permissions="rest-reader,read,rest-reader,update" quality="6"
                           collections="writeDocumentWithoutUriWithoutFormat"/>
@@ -71,7 +75,7 @@
   </flow>
 
   <flow name="writeDocumentWithoutUriWithJsonFormat">
-    <marklogic:delete-collection config-ref="config" collection="writeDocumentWithoutUriWithJsonFormat"/>
+    <flow-ref name="prepare-database"/>
     <marklogic:read-document config-ref="config" uri="/metadataSamples/json/hello.json"/>
     <marklogic:write-document config-ref="config" format="JSON" permissions="rest-reader,read,rest-reader,update"
                           quality="7" collections="writeDocumentWithoutUriWithJsonFormat"/>
@@ -80,7 +84,7 @@
   </flow>
 
   <flow name="writeDocumentWithoutUriWithXmlFormat">
-    <marklogic:delete-collection config-ref="config" collection="writeDocumentWithoutUriWithXmlFormat"/>
+    <flow-ref name="prepare-database"/>
     <marklogic:read-document config-ref="config" uri="/metadataSamples/xml/hello.xml"/>
     <marklogic:write-document config-ref="config" format="XML" permissions="rest-reader,read,rest-reader,update"
                           quality="8" collections="writeDocumentWithoutUriWithXmlFormat"/>
@@ -88,7 +92,7 @@
   </flow>
 
   <flow name="writeDocumentWithoutUriWithBinaryFormat">
-    <marklogic:delete-collection config-ref="config" collection="writeDocumentWithoutUriWithBinaryFormat"/>
+    <flow-ref name="prepare-database"/>
     <marklogic:read-document config-ref="config" uri="/metadataSamples/xml/hello.xml"/>
     <marklogic:write-document config-ref="config" format="BINARY" permissions="rest-reader,read,rest-reader,update"
                           quality="9" collections="writeDocumentWithoutUriWithBinaryFormat"/>
@@ -97,7 +101,7 @@
   </flow>
 
   <flow name="writeDocumentWithPrefixWithoutUuid">
-    <marklogic:delete-collection config-ref="config" collection="writeDocumentWithPrefixWithoutUuid"/>
+    <flow-ref name="prepare-database"/>
     <marklogic:read-document config-ref="config" uri="/metadataSamples/text/hello.text"/>
     <marklogic:write-document config-ref="config" uriPrefix="writeDocumentWithPrefixWithoutUuid" format="TEXT"
                           generateUUID="False"
@@ -107,7 +111,7 @@
   </flow>
 
   <flow name="writeDocumentWithPrefixAndSuffix">
-    <marklogic:delete-collection config-ref="config" collection="writeDocumentWithPrefixAndSuffix"/>
+    <flow-ref name="prepare-database"/>
     <marklogic:read-document config-ref="config" uri="/metadataSamples/json/hello.json"/>
     <marklogic:write-document config-ref="config" uriPrefix="writeDocumentWithPrefixAndSuffix" uriSuffix=".json"
                           format="JSON" generateUUID="False"
@@ -117,7 +121,7 @@
   </flow>
 
   <flow name="writeDocumentWithUuid">
-    <marklogic:delete-collection config-ref="config" collection="writeDocumentWithUuid"/>
+    <flow-ref name="prepare-database"/>
     <marklogic:read-document config-ref="config" uri="/metadataSamples/json/hello.json"/>
     <marklogic:write-document config-ref="config" format="JSON"
                           permissions="rest-reader,read,rest-reader,update" quality="12"

--- a/test-app/src/main/ml-config/security/amps/prepare-database.json
+++ b/test-app/src/main/ml-config/security/amps/prepare-database.json
@@ -1,0 +1,7 @@
+{
+  "local-name" : "prepare-database",
+  "namespace": "test",
+  "document-uri" : "/test-lib.xqy",
+  "modules-database" : "%%MODULES_DATABASE%%",
+  "role" : [ "admin" ]
+}

--- a/test-app/src/main/ml-config/security/roles/mule2-test-role.json
+++ b/test-app/src/main/ml-config/security/roles/mule2-test-role.json
@@ -14,6 +14,11 @@
       "privilege-name": "xdbc:eval",
       "action": "http://marklogic.com/xdmp/privileges/xdbc-eval",
       "kind": "execute"
+    },
+    {
+      "privilege-name": "xdmp:eval",
+      "action": "http://marklogic.com/xdmp/privileges/xdmp-eval",
+      "kind": "execute"
     }
   ]
 }

--- a/test-app/src/main/ml-data/dummy/collections.properties
+++ b/test-app/src/main/ml-data/dummy/collections.properties
@@ -1,0 +1,1 @@
+*=test-data,dummy

--- a/test-app/src/main/ml-data/dummy/dummy.xml
+++ b/test-app/src/main/ml-data/dummy/dummy.xml
@@ -1,0 +1,5 @@
+<text>
+  This is only here so that our operation for preparing a database can perform a search and match on a single document,
+  thus ensuring that the transform for preparing the database only runs once. It's technically fine if it runs multiple
+  times, but that's also not necessary.
+</text>

--- a/test-app/src/main/ml-modules/root/test-lib.xqy
+++ b/test-app/src/main/ml-modules/root/test-lib.xqy
@@ -1,0 +1,15 @@
+xquery version "1.0-ml";
+
+module namespace test = "test";
+
+(:
+Prepares the test database by deleting everything that wasn't loaded via the test app. Ensures that each test starts
+with a clean and expected database.
+
+Expected to have an amp applied to it so that temporal documents can be deleted. That also depends on the
+temporal collection having the "updates-admin-override" option enabled.
+:)
+declare function prepare-database() {
+  for $uri in cts:uris((), (), cts:not-query(cts:collection-query("test-data")))
+  return xdmp:document-delete($uri)
+};

--- a/test-app/src/main/ml-modules/transforms/prepare-database.xqy
+++ b/test-app/src/main/ml-modules/transforms/prepare-database.xqy
@@ -1,0 +1,13 @@
+xquery version "1.0-ml";
+
+module namespace transform = "http://marklogic.com/rest-api/transform/prepare-database";
+
+declare function transform(
+  $context as map:map,
+  $params as map:map,
+  $content as document-node()
+  ) as document-node()
+{
+  xdmp:eval("import module namespace test = 'test' at '/test-lib.xqy'; test:prepare-database()"),
+  $content
+};


### PR DESCRIPTION
This relies on an amped function so that mule2-test-user can temporarily get the `admin` role and thus delete any document, including temporal ones. 