### PR TITLE
DEVEXP-610 Can now do 1/2-way SSL with MarkLogic

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,25 @@ mvn test
 To create a new MUnit test, a good place to start is with batch-read-write-test-suite.xml in src/test/munit. This is a
 relatively simple test with some comments to explain things.
 
+### Manually testing SSL
+
+The connector supports 1-way and 2-way SSL with MarkLogic via Mule's `TLSContextFactory`, but we do not yet have 
+automated tests for this due to the complexity of the test setup (we do have tests for an insecure trust manager, but
+that is not a realistic approach in a production scenario). To manually verify this capability, please see 
+the "Testing 2-way SSL with the Java Client" internal Wiki page. If you do not have access to this, you can achieve
+a similar effect via the following steps:
+
+1. Clone the [MarkLogic Java Client project](https://github.com/marklogic/java-client-api).
+2. Follow the CONTRIBUTING.md instructions for getting the test application setup.
+3. Open `TwoWaySSLTest` and put a debugger breakpoint in the start of the `teardown` method.
+4. Run the debugger on one of the tests that does not test an error condition.
+
+With the debugger having paused the program, the `java-unittest` MarkLogic app server will be in a state where it 
+requires 2-way SSL. In addition, the test logging will identify the location of a Java keystore containing a private
+key for authenticating with MarkLogic along with the public certificate matching the `java-unittest`'s certificate 
+template. You can use that Java keystore for manually testing a Mule `TLSContextFactory`; the keystore will act as the
+truststore as well. 
+
 ### Generating code quality reports with SonarQube
 
 In order to use SonarQube, you must have used Docker to run this project's `docker-compose.yml` file and you must

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,6 @@ services:
   marklogic:
     image: "marklogicdb/marklogic-db:11.1.0-centos-1.1.0"
     platform: linux/amd64
-    restart: always
     environment:
       - MARKLOGIC_INIT=true
       - MARKLOGIC_ADMIN_USERNAME=admin
@@ -16,6 +15,7 @@ services:
     ports:
       - "8000-8002:8000-8002"
       - "8022:8022"
+      - "8023:8023"
 
   # Copied from https://docs.sonarsource.com/sonarqube/latest/setup-and-upgrade/install-the-server/#example-docker-compose-configuration .
   sonarqube:

--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
     <dependency>
       <groupId>com.marklogic</groupId>
       <artifactId>marklogic-client-api</artifactId>
-      <version>6.3.0</version>
+      <version>6.4.0</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/src/main/java/com/marklogic/mule/extension/api/HostnameVerifier.java
+++ b/src/main/java/com/marklogic/mule/extension/api/HostnameVerifier.java
@@ -1,0 +1,33 @@
+package com.marklogic.mule.extension.api;
+
+import com.marklogic.client.DatabaseClientFactory;
+
+/**
+ * Mirrors the Java Client's {@code SSLHostnameVerifier} class; this exists solely to avoid breaking changes if the
+ * Java Client class were to change.
+ */
+public enum HostnameVerifier {
+
+    ANY {
+        @Override
+        public DatabaseClientFactory.SSLHostnameVerifier getSslHostnameVerifier() {
+            return DatabaseClientFactory.SSLHostnameVerifier.ANY;
+        }
+    },
+
+    COMMON {
+        @Override
+        public DatabaseClientFactory.SSLHostnameVerifier getSslHostnameVerifier() {
+            return DatabaseClientFactory.SSLHostnameVerifier.COMMON;
+        }
+    },
+
+    STRICT {
+        @Override
+        public DatabaseClientFactory.SSLHostnameVerifier getSslHostnameVerifier() {
+            return DatabaseClientFactory.SSLHostnameVerifier.STRICT;
+        }
+    };
+
+    public abstract DatabaseClientFactory.SSLHostnameVerifier getSslHostnameVerifier();
+}

--- a/src/test/java/com/marklogic/mule/extension/ReadWithSSLTest.java
+++ b/src/test/java/com/marklogic/mule/extension/ReadWithSSLTest.java
@@ -1,0 +1,39 @@
+package com.marklogic.mule.extension;
+
+import org.junit.Test;
+
+import javax.net.ssl.SSLPeerUnverifiedException;
+
+import static org.junit.Assert.*;
+
+public class ReadWithSSLTest extends AbstractFlowTester {
+
+    @Override
+    protected String getFlowTestFile() {
+        return "insecure-ssl.xml";
+    }
+
+    @Test
+    public void insecureWithAnyHostnameVerifier() {
+        DocumentData data = runFlowGetDocumentData("hostnameVerifierANY");
+        assertEquals("/metadataSamples/json/hello.json", data.getAttributes().getUri());
+    }
+
+    @Test
+    public void insecureWithCommonHostnameVerifier() {
+        try {
+            runFlow("hostnameVerifierCOMMON");
+            fail("Expected an exception due to the COMMON hostname verifier not trusting the self-signed " +
+                "certificate in used by the test SSL app server. Only the ANY hostname verifier will work.");
+        } catch (Exception ex) {
+            assertTrue(
+                "Unexpected error; expected error to fail due to hostname not being verifiable: " + ex.getMessage(),
+                ex.getMessage().contains("javax.net.ssl.SSLPeerUnverifiedException: Hostname localhost not verified")
+            );
+            assertTrue(
+                "Unexpected exception; expecting a MarkLogicIOException and then SSLPeerUnverifiedException: " + ex.getCause(),
+                ex.getCause().getCause() instanceof SSLPeerUnverifiedException
+            );
+        }
+    }
+}

--- a/src/test/resources/insecure-ssl.xml
+++ b/src/test/resources/insecure-ssl.xml
@@ -1,0 +1,45 @@
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:tls="http://www.mulesoft.org/schema/mule/tls"
+      xmlns:marklogic="http://www.mulesoft.org/schema/mule/marklogic"
+      xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+        http://www.mulesoft.org/schema/mule/tls http://www.mulesoft.org/schema/mule/tls/current/mule-tls.xsd
+        http://www.mulesoft.org/schema/mule/marklogic http://www.mulesoft.org/schema/mule/marklogic/current/mule-marklogic.xsd">
+
+  <tls:context name="tlsContext">
+    <tls:trust-store insecure="true"/>
+  </tls:context>
+
+  <marklogic:config name="config" configId="configId">
+    <marklogic:connection
+        host="localhost"
+        port="8023"
+        username="mule2-test-user"
+        password="password"
+        authenticationType="DIGEST"
+        tlsContext="tlsContext"
+        hostnameVerifier="ANY"
+    />
+  </marklogic:config>
+
+  <marklogic:config name="config2" configId="configId2">
+    <marklogic:connection
+        host="localhost"
+        port="8023"
+        username="mule2-test-user"
+        password="password"
+        authenticationType="DIGEST"
+        tlsContext="tlsContext"
+        hostnameVerifier="COMMON"
+    />
+  </marklogic:config>
+
+  <flow name="hostnameVerifierANY">
+    <marklogic:read-document config-ref="config" uri="/metadataSamples/json/hello.json"/>
+  </flow>
+
+  <flow name="hostnameVerifierCOMMON">
+    <marklogic:read-document config-ref="config2" uri="/metadataSamples/json/hello.json"/>
+  </flow>
+
+</mule>

--- a/test-app/build.gradle
+++ b/test-app/build.gradle
@@ -3,6 +3,15 @@ plugins {
   id "com.marklogic.ml-gradle" version "4.6.0"
 }
 
+// Generate a temporary certificate so some SSL tests will work.
+ext {
+  def command = new com.marklogic.appdeployer.command.security.GenerateTemporaryCertificateCommand()
+  command.setTemplateIdOrName("mule-connector-test-template")
+  command.setCommonName("localhost")
+  command.setValidFor(365)
+  mlAppDeployer.commands.add(command)
+}
+
 task addQuality(type: com.marklogic.gradle.task.ServerEvalTask) {
   javascript =
     """

--- a/test-app/src/main/ml-config/security/certificate-templates/template.xml
+++ b/test-app/src/main/ml-config/security/certificate-templates/template.xml
@@ -1,0 +1,17 @@
+<certificate-template-properties xmlns="http://marklogic.com/manage">
+  <template-name>mule-connector-test-template</template-name>
+  <template-description>Used for marklogic-mule-connector testing</template-description>
+  <key-type>rsa</key-type>
+  <key-options />
+  <req>
+    <version>0</version>
+    <subject>
+      <countryName>US</countryName>
+      <stateOrProvinceName>VA</stateOrProvinceName>
+      <localityName>Falls Church</localityName>
+      <organizationName>MarkLogic</organizationName>
+      <organizationalUnitName>Engineering</organizationalUnitName>
+      <emailAddress>mule-connector@marklogic.com</emailAddress>
+    </subject>
+  </req>
+</certificate-template-properties>

--- a/test-app/src/main/ml-config/servers/ssl-server.json
+++ b/test-app/src/main/ml-config/servers/ssl-server.json
@@ -1,0 +1,16 @@
+{
+  "server-name" : "%%NAME%%-ssl",
+  "group-name" : "Default",
+  "server-type" : "http",
+  "enabled" : true,
+  "root" : "/",
+  "port" : 8023,
+  "authentication" : "digestbasic",
+  "content-database" : "%%DATABASE%%",
+  "modules-database" : "%%MODULES_DATABASE%%",
+  "ssl-certificate-template": "mule-connector-test-template",
+  "ssl-require-client-certificate": false,
+  "url-rewriter": "/MarkLogic/rest-api/rewriter.xml",
+  "error-handler": "/MarkLogic/rest-api/error-handler.xqy",
+  "rewrite-resolves-globally": true
+}


### PR DESCRIPTION
Added a new app server to the test-app for at least verifying that insecure SSL works / doesn't work. "Real" 1/2-way SSL requires manual testing for now. 