### PR TITLE
Renaming search-documents to read-documents

### DIFF
--- a/src/main/java/com/marklogic/mule/extension/Operations.java
+++ b/src/main/java/com/marklogic/mule/extension/Operations.java
@@ -142,13 +142,9 @@ public class Operations {
             uriPrefix, uriSuffix, generateUUID,  temporalCollection, restTransform, restTransformParameters, restTransformParametersDelimiter);
     }
 
-    /**
-     * Search for documents, returning the documents but not yet any metadata for them.
-     * Will eventually support many parameters here for searching.
-     */
     @MediaType(value = ANY, strict = false)
-    @DisplayName("Search Documents")
-    public PagingProvider<DatabaseClient, Result<InputStream, DocumentAttributes>> searchDocuments(
+    @DisplayName("Read Documents")
+    public PagingProvider<DatabaseClient, Result<InputStream, DocumentAttributes>> readDocuments(
         @DisplayName("Collection") @Optional(defaultValue = "") @Example("myCollection") String collection,
         @DisplayName("Query") @Text @Optional @Example("searchTerm") String query,
         @DisplayName("Query Type") @Optional QueryType queryType,

--- a/src/test/munit/batch-read-write-test-suite.xml
+++ b/src/test/munit/batch-read-write-test-suite.xml
@@ -25,7 +25,7 @@
 
 <!--  Flows must be defined outside the munit:test element.-->
   <flow name="readTenDocsWriteTwoBatches">
-    <marklogic:search-documents config-ref="MarkLogicConfig" collection="batch-input"/>
+    <marklogic:read-documents config-ref="MarkLogicConfig" collection="batch-input"/>
     <batch:job jobName="BatchJob">
       <batch:process-records>
         <batch:step name="Step1">

--- a/src/test/resources/manual-test-flows.xml
+++ b/src/test/resources/manual-test-flows.xml
@@ -34,7 +34,7 @@ You can copy/paste this into Anypoint for quick manual testing of the flows.
   -->
   <flow name="readTenDocsWriteTwoBatches">
     <http:listener config-ref="httpConfig" path="/many"/>
-    <marklogic:search-documents config-ref="config" collection="batch-input"/>
+    <marklogic:read-documents config-ref="config" collection="batch-input"/>
     <batch:job jobName="MyJob">
       <batch:process-records>
         <batch:step name="MyStep1">

--- a/src/test/resources/prepare-database-flow.xml
+++ b/src/test/resources/prepare-database-flow.xml
@@ -5,6 +5,6 @@
         http://www.mulesoft.org/schema/mule/marklogic http://www.mulesoft.org/schema/mule/marklogic/current/mule-marklogic.xsd">
 
   <flow name="prepare-database">
-    <marklogic:search-documents config-ref="config" collection="dummy" restTransform="prepare-database"/>
+    <marklogic:read-documents config-ref="config" collection="dummy" restTransform="prepare-database"/>
   </flow>
 </mule>

--- a/src/test/resources/search-documents-combined-queries.xml
+++ b/src/test/resources/search-documents-combined-queries.xml
@@ -15,48 +15,48 @@
   </marklogic:config>
 
   <flow name="search-documents-no-query">
-    <marklogic:search-documents config-ref="config" queryType="CombinedQuery"/>
+    <marklogic:read-documents config-ref="config" queryType="CombinedQuery"/>
   </flow>
 
   <flow name="search-documents-xml-combinedQuery">
-    <marklogic:search-documents config-ref="config" collection="test-data" queryType="CombinedQuery" queryFormat="XML">
+    <marklogic:read-documents config-ref="config" collection="test-data" queryType="CombinedQuery" queryFormat="XML">
       <marklogic:query>
         <![CDATA[<search xmlns="http://marklogic.com/appservices/search"><cts:word-query xmlns:cts="http://marklogic.com/cts"><cts:text xml:lang="en">world</cts:text></cts:word-query><options><return-metrics>false</return-metrics><return-qtext>false</return-qtext><debug>true</debug><transform-results apply="raw"/></options></search>]]></marklogic:query>
-    </marklogic:search-documents>
+    </marklogic:read-documents>
   </flow>
 
   <flow name="search-documents-json-combinedQuery">
-    <marklogic:search-documents config-ref="config" collection="test-data" queryType="CombinedQuery" queryFormat="JSON">
+    <marklogic:read-documents config-ref="config" collection="test-data" queryType="CombinedQuery" queryFormat="JSON">
       <marklogic:query>
         <![CDATA[{ "search": { "query": { "query": { "queries": [{"term-query":{"text":["world"]}}] } } } }]]></marklogic:query>
-    </marklogic:search-documents>
+    </marklogic:read-documents>
   </flow>
 
   <flow name="search-documents-xml-combinedQuery-noMatches">
-    <marklogic:search-documents config-ref="config" collection="test-data" queryType="CombinedQuery" queryFormat="XML">
+    <marklogic:read-documents config-ref="config" collection="test-data" queryType="CombinedQuery" queryFormat="XML">
       <marklogic:query>
         <![CDATA[<search xmlns="http://marklogic.com/appservices/search"><cts:word-query xmlns:cts="http://marklogic.com/cts"><cts:text xml:lang="en">thisTermDoesNotExist</cts:text></cts:word-query><options><return-metrics>false</return-metrics><return-qtext>false</return-qtext><debug>true</debug><transform-results apply="raw"/></options></search>]]></marklogic:query>
-    </marklogic:search-documents>
+    </marklogic:read-documents>
   </flow>
 
   <flow name="search-documents-json-combinedQuery-noMatches">
-    <marklogic:search-documents config-ref="config" collection="test-data" queryType="CombinedQuery" queryFormat="JSON">
+    <marklogic:read-documents config-ref="config" collection="test-data" queryType="CombinedQuery" queryFormat="JSON">
       <marklogic:query>
         <![CDATA[{ "search": { "query": { "query": { "queries": [{"term-query":{"text":["antidisestablishmentarianism"]}}] } } } }]]></marklogic:query>
-    </marklogic:search-documents>
+    </marklogic:read-documents>
   </flow>
 
   <flow name="search-documents-xml-combinedQuery-badXml">
-    <marklogic:search-documents config-ref="config" collection="test-data" queryType="CombinedQuery" queryFormat="XML">
+    <marklogic:read-documents config-ref="config" collection="test-data" queryType="CombinedQuery" queryFormat="XML">
       <marklogic:query>
         <![CDATA[<search xmlns="http://marklogic.com/appservices/search"><cts:word-query]]></marklogic:query>
-    </marklogic:search-documents>
+    </marklogic:read-documents>
   </flow>
 
   <flow name="search-documents-json-combinedQuery-badJson">
-    <marklogic:search-documents config-ref="config" collection="test-data" queryType="CombinedQuery" queryFormat="JSON">
+    <marklogic:read-documents config-ref="config" collection="test-data" queryType="CombinedQuery" queryFormat="JSON">
       <marklogic:query><![CDATA[{ "search": { "query": { "query": { "queries": [{"term-query"]]></marklogic:query>
-    </marklogic:search-documents>
+    </marklogic:read-documents>
   </flow>
 
 </mule>

--- a/src/test/resources/search-documents-serialized-cts-queries.xml
+++ b/src/test/resources/search-documents-serialized-cts-queries.xml
@@ -15,38 +15,38 @@
   </marklogic:config>
 
   <flow name="search-documents-no-query">
-    <marklogic:search-documents config-ref="config" queryType="SerializedCtsQuery"/>
+    <marklogic:read-documents config-ref="config" queryType="SerializedCtsQuery"/>
   </flow>
 
   <flow name="search-documents-xml-serializedCtsQuery">
-    <marklogic:search-documents config-ref="config" collection="test-data" queryType="SerializedCtsQuery"
+    <marklogic:read-documents config-ref="config" collection="test-data" queryType="SerializedCtsQuery"
                             queryFormat="XML">
       <marklogic:query>
         <![CDATA[<cts:word-query xmlns:cts="http://marklogic.com/cts"><cts:text xml:lang="en">world</cts:text></cts:word-query>]]></marklogic:query>
-    </marklogic:search-documents>
+    </marklogic:read-documents>
   </flow>
 
   <flow name="search-documents-json-serializedCtsQuery">
-    <marklogic:search-documents config-ref="config" collection="test-data" queryType="SerializedCtsQuery"
+    <marklogic:read-documents config-ref="config" collection="test-data" queryType="SerializedCtsQuery"
                             queryFormat="JSON">
       <marklogic:query>
         <![CDATA[{ "query": { "queries": [{ "term-query": { "text": [ "world" ] } }] } }]]></marklogic:query>
-    </marklogic:search-documents>
+    </marklogic:read-documents>
   </flow>
 
   <flow name="search-documents-serializedCtsQuery-badXml">
-    <marklogic:search-documents config-ref="config" collection="test-data" queryType="SerializedCtsQuery"
+    <marklogic:read-documents config-ref="config" collection="test-data" queryType="SerializedCtsQuery"
                             queryFormat="XML">
       <marklogic:query><![CDATA[<cts:word-query xmlns:cts="http://marklogic.com/cts"><cts:text]]></marklogic:query>
-    </marklogic:search-documents>
+    </marklogic:read-documents>
   </flow>
 
   <flow name="search-documents-serializedCtsQuery-noMatches">
-    <marklogic:search-documents config-ref="config" collection="test-data" queryType="SerializedCtsQuery"
+    <marklogic:read-documents config-ref="config" collection="test-data" queryType="SerializedCtsQuery"
                             queryFormat="JSON">
       <marklogic:query>
         <![CDATA[{ "query": { "queries": [{ "term-query": { "text": [ "antidisestablishmentarianism" ] } }] } }]]></marklogic:query>
-    </marklogic:search-documents>
+    </marklogic:read-documents>
   </flow>
 
 </mule>

--- a/src/test/resources/search-documents-string-queries.xml
+++ b/src/test/resources/search-documents-string-queries.xml
@@ -15,19 +15,19 @@
   </marklogic:config>
 
   <flow name="search-documents-no-query">
-    <marklogic:search-documents config-ref="config">
-    </marklogic:search-documents>
+    <marklogic:read-documents config-ref="config">
+    </marklogic:read-documents>
   </flow>
 
   <flow name="search-documents-no-query-with-collection">
-    <marklogic:search-documents config-ref="config" collection="batch-input">
-    </marklogic:search-documents>
+    <marklogic:read-documents config-ref="config" collection="batch-input">
+    </marklogic:read-documents>
   </flow>
 
   <flow name="search-documents-query-with-no-matches">
-    <marklogic:search-documents config-ref="config">
+    <marklogic:read-documents config-ref="config">
       <marklogic:query><![CDATA[antidisestablishmentarianism]]></marklogic:query>
-    </marklogic:search-documents>
+    </marklogic:read-documents>
   </flow>
 
 </mule>

--- a/src/test/resources/search-documents-structured-queries.xml
+++ b/src/test/resources/search-documents-structured-queries.xml
@@ -15,38 +15,38 @@
   </marklogic:config>
 
   <flow name="search-documents-no-query">
-    <marklogic:search-documents config-ref="config" queryType="StructuredQuery"/>
+    <marklogic:read-documents config-ref="config" queryType="StructuredQuery"/>
   </flow>
 
   <flow name="search-documents-xml-structuredQuery">
-    <marklogic:search-documents config-ref="config" collection="test-data" queryType="StructuredQuery"
+    <marklogic:read-documents config-ref="config" collection="test-data" queryType="StructuredQuery"
                             queryFormat="XML">
       <marklogic:query>
         <![CDATA[<query xmlns='http://marklogic.com/appservices/search'><term-query><text>world</text></term-query></query>]]></marklogic:query>
-    </marklogic:search-documents>
+    </marklogic:read-documents>
   </flow>
 
   <flow name="search-documents-json-structuredQuery">
-    <marklogic:search-documents config-ref="config" collection="test-data" queryType="StructuredQuery"
+    <marklogic:read-documents config-ref="config" collection="test-data" queryType="StructuredQuery"
                             queryFormat="JSON">
       <marklogic:query>
         <![CDATA[{ "query": { "queries": [{ "term-query": { "text": [ "world" ] } }] } }]]></marklogic:query>
-    </marklogic:search-documents>
+    </marklogic:read-documents>
   </flow>
 
   <flow name="search-documents-structuredQuery-badXml">
-    <marklogic:search-documents config-ref="config" collection="test-data" queryType="StructuredQuery"
+    <marklogic:read-documents config-ref="config" collection="test-data" queryType="StructuredQuery"
                             queryFormat="XML">
       <marklogic:query><![CDATA[<query xmlns='http://marklogic.com/appservices/search]]></marklogic:query>
-    </marklogic:search-documents>
+    </marklogic:read-documents>
   </flow>
 
   <flow name="search-documents-structuredQuery-noMatches">
-    <marklogic:search-documents config-ref="config" collection="test-data" queryType="StructuredQuery"
+    <marklogic:read-documents config-ref="config" collection="test-data" queryType="StructuredQuery"
                             queryFormat="JSON">
       <marklogic:query>
         <![CDATA[{ "query": { "queries": [{ "term-query": { "text": [ "antidisestablishmentarianism" ] } }] } }]]></marklogic:query>
-    </marklogic:search-documents>
+    </marklogic:read-documents>
   </flow>
 
 </mule>

--- a/src/test/resources/search-documents-with-metadata.xml
+++ b/src/test/resources/search-documents-with-metadata.xml
@@ -16,23 +16,23 @@
 
 
   <flow name="search-batch-input-documents-with-metadata-default">
-    <marklogic:search-documents config-ref="config" collection="batch-input"/>
+    <marklogic:read-documents config-ref="config" collection="batch-input"/>
   </flow>
 
   <flow name="search-test-data-documents-with-metadata-all">
-    <marklogic:search-documents config-ref="config" collection="test-data" categories="all"/>
+    <marklogic:read-documents config-ref="config" collection="test-data" categories="all"/>
   </flow>
 
   <flow name="search-binary-documents-with-metadata-collections">
-    <marklogic:search-documents config-ref="config" collection="binary-data" categories="collections"/>
+    <marklogic:read-documents config-ref="config" collection="binary-data" categories="collections"/>
   </flow>
 
   <flow name="search-text-documents-with-metadata-permissions">
-    <marklogic:search-documents config-ref="config" collection="text-data" categories="permissions"/>
+    <marklogic:read-documents config-ref="config" collection="text-data" categories="permissions"/>
   </flow>
 
   <flow name="search-text-documents-with-metadata-permissionsProperties">
-    <marklogic:search-documents config-ref="config" collection="text-data" categories="permissions,properties"/>
+    <marklogic:read-documents config-ref="config" collection="text-data" categories="permissions,properties"/>
   </flow>
 
 </mule>

--- a/src/test/resources/search-documents-with-options.xml
+++ b/src/test/resources/search-documents-with-options.xml
@@ -15,31 +15,31 @@
   </marklogic:config>
 
   <flow name="search-documents-with-maxResults">
-    <marklogic:search-documents config-ref="config" collection="batch-input" maxResults="9"/>
+    <marklogic:read-documents config-ref="config" collection="batch-input" maxResults="9"/>
   </flow>
 
   <flow name="search-documents-without-consistent-timestamp">
-    <marklogic:search-documents config-ref="config" collection="batch-input" maxResults="9" consistentSnapshot="False"/>
+    <marklogic:read-documents config-ref="config" collection="batch-input" maxResults="9" consistentSnapshot="False"/>
   </flow>
 
   <flow name="search-documents-search-term-with-options">
-    <marklogic:search-documents config-ref="config" searchOptions="testOptions">
+    <marklogic:read-documents config-ref="config" searchOptions="testOptions">
       <marklogic:query><![CDATA[testConstraint:3]]></marklogic:query>
-    </marklogic:search-documents>
+    </marklogic:read-documents>
   </flow>
 
   <flow name="search-documents-search-term-without-options">
-    <marklogic:search-documents config-ref="config">
+    <marklogic:read-documents config-ref="config">
       <marklogic:query><![CDATA[testConstraint:3]]></marklogic:query>
-    </marklogic:search-documents>
+    </marklogic:read-documents>
   </flow>
 
   <flow name="search-documents-within-directory">
-    <marklogic:search-documents config-ref="config" collection="test-data" directory="/batch"/>
+    <marklogic:read-documents config-ref="config" collection="test-data" directory="/batch"/>
   </flow>
 
   <flow name="search-documents-with-transform">
-    <marklogic:search-documents config-ref="config" collection="json-data" restTransform="testTransform"
+    <marklogic:read-documents config-ref="config" collection="json-data" restTransform="testTransform"
                                 restTransformParameters="hello;Hola;world;Mundo" restTransformParametersDelimiter=";"/>
   </flow>
 

--- a/src/test/resources/write-document.xml
+++ b/src/test/resources/write-document.xml
@@ -53,7 +53,7 @@
     <marklogic:read-document config-ref="config" uri="/metadataSamples/text/hello.text"/>
     <marklogic:write-documents config-ref="config" format="TEXT" permissions="rest-reader,read,rest-reader,update"
                           quality="5" collections="writeDocumentWithoutUriWithTextFormat"/>
-    <marklogic:search-documents config-ref="config" collection="writeDocumentWithoutUriWithTextFormat"
+    <marklogic:read-documents config-ref="config" collection="writeDocumentWithoutUriWithTextFormat"
                             categories="all"/>
   </flow>
 
@@ -61,14 +61,14 @@
     <marklogic:read-document config-ref="config" uri="/metadataSamples/text/hello.text"/>
     <marklogic:write-documents config-ref="config" permissions="rest-reader,read,rest-reader,update" quality="6"
                           collections="writeDocumentWithoutUriWithoutFormat"/>
-    <marklogic:search-documents config-ref="config" collection="writeDocumentWithoutUriWithoutFormat" categories="all"/>
+    <marklogic:read-documents config-ref="config" collection="writeDocumentWithoutUriWithoutFormat" categories="all"/>
   </flow>
 
   <flow name="writeDocumentWithoutUriWithJsonFormat">
     <marklogic:read-document config-ref="config" uri="/metadataSamples/json/hello.json"/>
     <marklogic:write-documents config-ref="config" format="JSON" permissions="rest-reader,read,rest-reader,update"
                           quality="7" collections="writeDocumentWithoutUriWithJsonFormat"/>
-    <marklogic:search-documents config-ref="config" collection="writeDocumentWithoutUriWithJsonFormat"
+    <marklogic:read-documents config-ref="config" collection="writeDocumentWithoutUriWithJsonFormat"
                             categories="all"/>
   </flow>
 
@@ -76,14 +76,14 @@
     <marklogic:read-document config-ref="config" uri="/metadataSamples/xml/hello.xml"/>
     <marklogic:write-documents config-ref="config" format="XML" permissions="rest-reader,read,rest-reader,update"
                           quality="8" collections="writeDocumentWithoutUriWithXmlFormat"/>
-    <marklogic:search-documents config-ref="config" collection="writeDocumentWithoutUriWithXmlFormat" categories="all"/>
+    <marklogic:read-documents config-ref="config" collection="writeDocumentWithoutUriWithXmlFormat" categories="all"/>
   </flow>
 
   <flow name="writeDocumentWithoutUriWithBinaryFormat">
     <marklogic:read-document config-ref="config" uri="/metadataSamples/xml/hello.xml"/>
     <marklogic:write-documents config-ref="config" format="BINARY" permissions="rest-reader,read,rest-reader,update"
                           quality="9" collections="writeDocumentWithoutUriWithBinaryFormat"/>
-    <marklogic:search-documents config-ref="config" collection="writeDocumentWithoutUriWithBinaryFormat"
+    <marklogic:read-documents config-ref="config" collection="writeDocumentWithoutUriWithBinaryFormat"
                             categories="all"/>
   </flow>
 
@@ -110,7 +110,7 @@
     <marklogic:write-documents config-ref="config" format="JSON"
                           permissions="rest-reader,read,rest-reader,update" quality="12"
                           collections="writeDocumentWithUuid"/>
-    <marklogic:search-documents config-ref="config" collection="writeDocumentWithUuid" categories="all"/>
+    <marklogic:read-documents config-ref="config" collection="writeDocumentWithUuid" categories="all"/>
   </flow>
 
   <flow name="writeDocumentWithTemporalCollection">
@@ -136,7 +136,7 @@
     <marklogic:write-multiple-documents config-ref="config" format="TEXT" collections="writeDocumentWithArrayInput"
                                permissions="rest-reader,read,rest-reader,update" quality="15" generateUUID="True"
                                uriPrefix="/writeDocumentWithArrayInput/"/>
-    <marklogic:search-documents config-ref="config" collection="writeDocumentWithArrayInput" categories="all"/>
+    <marklogic:read-documents config-ref="config" collection="writeDocumentWithArrayInput" categories="all"/>
   </flow>
 
 </mule>


### PR DESCRIPTION
No functional changes, just renaming. Will remove "read-document" soon. 