### PR TITLE
DEVEXP-648 Fixing Sonar warnings about lack of "assert"

### DIFF
--- a/src/test/java/com/marklogic/mule/extension/AbstractFlowTester.java
+++ b/src/test/java/com/marklogic/mule/extension/AbstractFlowTester.java
@@ -55,6 +55,10 @@ public abstract class AbstractFlowTester extends MuleArtifactFunctionalTestCase 
         return result;
     }
 
+    int runFlowForDocumentCount(String flowName) {
+        return runFlowForDocumentDataList(flowName).size();
+    }
+
     private DocumentData toDocumentData(Message message) {
         String content;
         try {

--- a/src/test/java/com/marklogic/mule/extension/SearchDocumentsCombinedQueriesTest.java
+++ b/src/test/java/com/marklogic/mule/extension/SearchDocumentsCombinedQueriesTest.java
@@ -4,6 +4,7 @@ import org.junit.Test;
 
 import java.util.List;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class SearchDocumentsCombinedQueriesTest extends AbstractFlowTester {
@@ -15,40 +16,31 @@ public class SearchDocumentsCombinedQueriesTest extends AbstractFlowTester {
 
     @Test
     public void noQuery() {
-        List<DocumentData> documentDataList = runFlowForDocumentDataList("search-documents-no-query");
-        assertTrue(1 < documentDataList.size());
+        assertTrue(1 < runFlowForDocumentCount("search-documents-no-query"));
     }
 
     @Test
     public void combinedXmlQuery() {
-        runFlowAndVerifyMessageCount(
-            "search-documents-xml-combinedQuery",
-            3,
-            "3 docs are expected to have 'world' in them");
+        assertEquals("3 docs are expected to have 'world' in them",
+            3, runFlowForDocumentCount("search-documents-xml-combinedQuery"));
     }
 
     @Test
     public void combinedJsonQuery() {
-        runFlowAndVerifyMessageCount(
-            "search-documents-json-combinedQuery",
-            3,
-            "3 docs are expected to have 'world' in them");
+        assertEquals("3 docs are expected to have 'world' in them",
+            3, runFlowForDocumentCount("search-documents-json-combinedQuery"));
     }
 
     @Test
     public void combinedXmlQueryWithNoMatches() {
-        runFlowAndVerifyMessageCount(
-            "search-documents-xml-combinedQuery-noMatches",
-            0,
-            "A search term with no matches should return no documents");
+        assertEquals("A search term with no matches should return no documents",
+            0, runFlowForDocumentCount("search-documents-xml-combinedQuery-noMatches"));
     }
 
     @Test
     public void combinedJsonQueryWithNoMatches() {
-        runFlowAndVerifyMessageCount(
-            "search-documents-json-combinedQuery-noMatches",
-            0,
-            "A search term with no matches should return no documents");
+        assertEquals("A search term with no matches should return no documents",
+            0, runFlowForDocumentCount("search-documents-json-combinedQuery-noMatches"));
     }
 
     @Test(expected = RuntimeException.class)

--- a/src/test/java/com/marklogic/mule/extension/SearchDocumentsSerializedCtsQueriesTest.java
+++ b/src/test/java/com/marklogic/mule/extension/SearchDocumentsSerializedCtsQueriesTest.java
@@ -2,8 +2,7 @@ package com.marklogic.mule.extension;
 
 import org.junit.Test;
 
-import java.util.List;
-
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @SuppressWarnings("unchecked")
@@ -16,32 +15,25 @@ public class SearchDocumentsSerializedCtsQueriesTest extends AbstractFlowTester 
 
     @Test
     public void noQuery() {
-        List<DocumentData> documentDataList = runFlowForDocumentDataList("search-documents-no-query");
-        assertTrue(1 < documentDataList.size());
+        assertTrue(1 < runFlowForDocumentCount("search-documents-no-query"));
     }
 
     @Test
     public void serializedXmlQuery() {
-        runFlowAndVerifyMessageCount(
-            "search-documents-xml-serializedCtsQuery",
-            3,
-            "3 docs are expected to have 'world' in them");
+        assertEquals("3 docs are expected to have 'world' in them",
+            3, runFlowForDocumentCount("search-documents-xml-serializedCtsQuery"));
     }
 
     @Test
     public void serializedJsonQuery() {
-        runFlowAndVerifyMessageCount(
-            "search-documents-json-serializedCtsQuery",
-            3,
-            "3 docs are expected to have 'world' in them");
+        assertEquals("3 docs are expected to have 'world' in them",
+            3, runFlowForDocumentCount("search-documents-json-serializedCtsQuery"));
     }
 
     @Test
     public void serializedJsonQueryWithNoMatches() {
-        runFlowAndVerifyMessageCount(
-            "search-documents-serializedCtsQuery-noMatches",
-            0,
-            "A search term with no matches should return no documents");
+        assertEquals("A search term with no matches should return no documents",
+            0, runFlowForDocumentCount("search-documents-serializedCtsQuery-noMatches"));
     }
 
     @Test(expected = RuntimeException.class)

--- a/src/test/java/com/marklogic/mule/extension/SearchDocumentsStringQueriesTest.java
+++ b/src/test/java/com/marklogic/mule/extension/SearchDocumentsStringQueriesTest.java
@@ -4,6 +4,7 @@ import org.junit.Test;
 
 import java.util.List;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class SearchDocumentsStringQueriesTest extends AbstractFlowTester {
@@ -15,8 +16,8 @@ public class SearchDocumentsStringQueriesTest extends AbstractFlowTester {
 
     @Test
     public void noQuery() {
-        List<DocumentData> list = runFlowForDocumentDataList("search-documents-no-query");
-        assertTrue("Expecting all documents to be returned, which is far greater than 1", 1 < list.size());
+        assertTrue("Expecting all documents to be returned, which is far greater than 1",
+            1 < runFlowForDocumentCount("search-documents-no-query"));
     }
 
     @Test
@@ -25,15 +26,12 @@ public class SearchDocumentsStringQueriesTest extends AbstractFlowTester {
             "search-documents-no-query-with-collection",
             10,
             "For the given collection, exactly 10 documents should be returned.");
-        List<DocumentData> noQueryDocumentDataList = runFlowForDocumentDataList("search-documents-no-query");
-        assertTrue(collectionDocumentDataList.size() < noQueryDocumentDataList.size());
+        assertTrue(collectionDocumentDataList.size() < runFlowForDocumentCount("search-documents-no-query"));
     }
 
     @Test
     public void queryWithNoMatches() {
-        runFlowAndVerifyMessageCount(
-            "search-documents-query-with-no-matches",
-            0,
-            "A search term with no matches should return no documents");
+        assertEquals("A search term with no matches should return no documents",
+            0, runFlowForDocumentCount("search-documents-query-with-no-matches"));
     }
 }

--- a/src/test/java/com/marklogic/mule/extension/SearchDocumentsStructuredQueriesTest.java
+++ b/src/test/java/com/marklogic/mule/extension/SearchDocumentsStructuredQueriesTest.java
@@ -2,8 +2,7 @@ package com.marklogic.mule.extension;
 
 import org.junit.Test;
 
-import java.util.List;
-
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class SearchDocumentsStructuredQueriesTest extends AbstractFlowTester {
@@ -15,32 +14,25 @@ public class SearchDocumentsStructuredQueriesTest extends AbstractFlowTester {
 
     @Test
     public void noQuery() {
-        List<DocumentData> documentDataList = runFlowForDocumentDataList("search-documents-no-query");
-        assertTrue(1 < documentDataList.size());
+        assertTrue(1 < runFlowForDocumentCount("search-documents-no-query"));
     }
 
     @Test
     public void structuredXmlQuery() {
-        runFlowAndVerifyMessageCount(
-            "search-documents-xml-structuredQuery",
-            3,
-            "3 docs are expected to have 'world' in them");
+        assertEquals("3 docs are expected to have 'world' in them",
+            3, runFlowForDocumentCount("search-documents-xml-structuredQuery"));
     }
 
     @Test
     public void structuredJsonQuery() {
-        runFlowAndVerifyMessageCount(
-            "search-documents-json-structuredQuery",
-            3,
-            "3 docs are expected to have 'world' in them");
+        assertEquals("3 docs are expected to have 'world' in them",
+            3, runFlowForDocumentCount("search-documents-json-structuredQuery"));
     }
 
     @Test
     public void structuredJsonQueryWithNoMatches() {
-        runFlowAndVerifyMessageCount(
-            "search-documents-structuredQuery-noMatches",
-            0,
-            "A search term with no matches should return no documents");
+        assertEquals("A search term with no matches should return no documents",
+            0, runFlowForDocumentCount("search-documents-structuredQuery-noMatches"));
     }
 
     @Test(expected = RuntimeException.class)

--- a/src/test/java/com/marklogic/mule/extension/SearchDocumentsWithOptionsTest.java
+++ b/src/test/java/com/marklogic/mule/extension/SearchDocumentsWithOptionsTest.java
@@ -15,18 +15,14 @@ public class SearchDocumentsWithOptionsTest extends AbstractFlowTester {
 
     @Test
     public void searchDocuments_DefaultMetadata() {
-        runFlowAndVerifyMessageCount(
-            "search-documents-with-maxResults",
-            9,
-            "With maxResults set, only that many documents should be returned.");
+        assertEquals("With maxResults set, only that many documents should be returned.",
+            9, runFlowForDocumentCount("search-documents-with-maxResults"));
     }
 
     @Test
-    public void searchDocuments_WithoutConsistentTimestamp() {
-        runFlowAndVerifyMessageCount(
-            "search-documents-without-consistent-timestamp",
-            9,
-            "This only verifies that setting the consistentSnapshot parameter to false does not break anything.");
+    public void searchDocuments_WithoutConsistentSnapshot() {
+        assertEquals("This only verifies that setting the consistentSnapshot parameter to false does not break anything.",
+            9, runFlowForDocumentCount("search-documents-without-consistent-snapshot"));
     }
 
     @Test
@@ -40,22 +36,18 @@ public class SearchDocumentsWithOptionsTest extends AbstractFlowTester {
 
     @Test
     public void searchDocuments_SearchTermWithoutOptions() {
-        runFlowAndVerifyMessageCount(
-            "search-documents-search-term-without-options",
-            0,
-            "Without search options, the search string should not have any matches");
+        assertEquals("Without search options, the search string should not have any matches",
+            0, runFlowForDocumentCount("search-documents-search-term-without-options"));
     }
 
     @Test
     public void searchDocuments_withinDirectory() {
-        runFlowAndVerifyMessageCount(
-            "search-documents-within-directory",
-            10,
-            "Only the documents in the specified directory should be returned.");
+        assertEquals("Only the documents in the specified directory should be returned.",
+            10, runFlowForDocumentCount("search-documents-within-directory"));
     }
 
     @Test
-    public void searchDocuments_withTransform() throws Exception {
+    public void searchDocuments_withTransform() {
         List<DocumentData> documentDataList = runFlowAndVerifyMessageCount(
             "search-documents-with-transform",
             1,

--- a/src/test/resources/search-documents-with-options.xml
+++ b/src/test/resources/search-documents-with-options.xml
@@ -18,7 +18,7 @@
     <marklogic:read-documents config-ref="config" collections="batch-input" maxResults="9"/>
   </flow>
 
-  <flow name="search-documents-without-consistent-timestamp">
+  <flow name="search-documents-without-consistent-snapshot">
     <marklogic:read-documents config-ref="config" collections="batch-input" maxResults="9" consistentSnapshot="False"/>
   </flow>
 


### PR DESCRIPTION
Added `runFlowForDocumentCount` so that `assertEquals` can be used in each test method, thereby making Sonar happy and keeping duplication of logic to a minimum. 