### PR TITLE
Bumped Java Client to 6.4.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <dependency>
       <groupId>com.marklogic</groupId>
       <artifactId>marklogic-client-api</artifactId>
-      <version>6.4.0</version>
+      <version>6.4.1</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/src/main/java/com/marklogic/mule/extension/AbstractPagingProvider.java
+++ b/src/main/java/com/marklogic/mule/extension/AbstractPagingProvider.java
@@ -48,7 +48,7 @@ abstract class AbstractPagingProvider {
         int startingPosition = (currentPage * pageLength) + 1;
         documentManager.setPageLength(pageLength);
         DocumentPage documentPage = serverTimestamp != null ?
-            ((GenericDocumentImpl) documentManager).search(queryDefinition, startingPosition, serverTimestamp) :
+            documentManager.search(queryDefinition, startingPosition, serverTimestamp) :
             documentManager.search(queryDefinition, startingPosition);
 
         while (documentPage.hasNext()) {

--- a/src/test/java/com/marklogic/mule/extension/MetadataVerifier.java
+++ b/src/test/java/com/marklogic/mule/extension/MetadataVerifier.java
@@ -135,7 +135,7 @@ public class MetadataVerifier {
 
     private void verifyMetadataValues() {
         if (expectedMetadataValueCount != null) {
-            assertEquals(((long) expectedMetadataValueCount), attributes.getMetadataValues().size());
+            assertEquals(((int) expectedMetadataValueCount), attributes.getMetadataValues().size());
         }
         if (expectedMetadataValues != null) {
             for (int i = 0; i < expectedMetadataValues.length; i = i + 2) {

--- a/src/test/java/com/marklogic/mule/extension/SearchDocumentsWithMetadataTest.java
+++ b/src/test/java/com/marklogic/mule/extension/SearchDocumentsWithMetadataTest.java
@@ -1,7 +1,6 @@
 package com.marklogic.mule.extension;
 
 import com.marklogic.mule.extension.api.DocumentAttributes;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.List;
@@ -96,8 +95,17 @@ public class SearchDocumentsWithMetadataTest extends AbstractFlowTester {
     }
 
     @Test
-    @Ignore
     public void queryDataDocuments_MetadataValuesOnly() {
-        // TODO - Ignoring this until the bug is fixed in the Java Client
+        List<DocumentData> documentDataList = runFlowForDocumentDataList("search-text-data-documents-with-metadata-values");
+        for (DocumentData documentData : documentDataList) {
+            DocumentAttributes documentAttributes = documentData.getAttributes();
+            MetadataVerifier.assertMetadata(documentAttributes, null)
+                .collections(0)
+                .permissions(0)
+                .properties(0)
+                .metadataValues(1, "hello", "world")
+                .quality(0)
+                .verify();
+        }
     }
 }

--- a/src/test/resources/search-documents-with-metadata.xml
+++ b/src/test/resources/search-documents-with-metadata.xml
@@ -38,4 +38,8 @@
     <marklogic:read-documents config-ref="config" collections="text-data" categories="all"/>
   </flow>
 
+  <flow name="search-text-data-documents-with-metadata-values">
+    <marklogic:read-documents config-ref="config" collections="text-data" categories="metadatavalues"/>
+  </flow>
+
 </mule>


### PR DESCRIPTION
Got test working for only metadata-values and removed now-unnecessary cast for GenericDocumentManager. 