### PR TITLE
Moved Error classes out of api package

### DIFF
--- a/src/main/java/com/marklogic/mule/extension/ConnectionProvider.java
+++ b/src/main/java/com/marklogic/mule/extension/ConnectionProvider.java
@@ -21,7 +21,6 @@ import com.marklogic.client.DatabaseClientFactory;
 import com.marklogic.client.impl.SSLUtil;
 import com.marklogic.mule.extension.api.AuthenticationType;
 import com.marklogic.mule.extension.api.ConnectionType;
-import com.marklogic.mule.extension.api.ErrorType;
 import com.marklogic.mule.extension.api.HostnameVerifier;
 import org.mule.runtime.api.connection.CachedConnectionProvider;
 import org.mule.runtime.api.connection.ConnectionValidationResult;
@@ -177,6 +176,9 @@ public class ConnectionProvider implements CachedConnectionProvider<DatabaseClie
         try {
             builder.withSSLContext(tlsContextFactory.createSslContext());
         } catch (Exception e) {
+            // Have not found a way to cause this error to happen yet, but createSslContext() can throw a
+            // checked exception so it needs to be handled. Attempts at providing invalid inputs result in
+            // the "initialize()" call failing instead.
             String message = String.format("Unable to create SSL context; cause: %s", e.getMessage());
             throw new ModuleException(message, ErrorType.CONNECTION_ERROR, e);
         }

--- a/src/main/java/com/marklogic/mule/extension/ErrorType.java
+++ b/src/main/java/com/marklogic/mule/extension/ErrorType.java
@@ -1,10 +1,9 @@
-package com.marklogic.mule.extension.api;
+package com.marklogic.mule.extension;
 
 import org.mule.runtime.extension.api.error.ErrorTypeDefinition;
 
 public enum ErrorType implements ErrorTypeDefinition<ErrorType> {
 
-    // TODO Test that this works.
     CONNECTION_ERROR,
 
     XML_TRANSFORMER_ERROR;

--- a/src/main/java/com/marklogic/mule/extension/ExecuteErrorsProvider.java
+++ b/src/main/java/com/marklogic/mule/extension/ExecuteErrorsProvider.java
@@ -1,4 +1,4 @@
-package com.marklogic.mule.extension.api;
+package com.marklogic.mule.extension;
 
 import org.mule.runtime.extension.api.annotation.error.ErrorTypeProvider;
 import org.mule.runtime.extension.api.error.ErrorTypeDefinition;

--- a/src/main/java/com/marklogic/mule/extension/MarkLogicExtension.java
+++ b/src/main/java/com/marklogic/mule/extension/MarkLogicExtension.java
@@ -15,7 +15,6 @@
  */
 package com.marklogic.mule.extension;
 
-import com.marklogic.mule.extension.api.ErrorType;
 import org.mule.runtime.extension.api.annotation.Configurations;
 import org.mule.runtime.extension.api.annotation.Extension;
 import org.mule.runtime.extension.api.annotation.dsl.xml.Xml;

--- a/src/main/java/com/marklogic/mule/extension/Operations.java
+++ b/src/main/java/com/marklogic/mule/extension/Operations.java
@@ -16,7 +16,6 @@
 package com.marklogic.mule.extension;
 
 import com.marklogic.client.DatabaseClient;
-import com.marklogic.mule.extension.api.ExecuteErrorsProvider;
 import org.mule.runtime.extension.api.annotation.error.Throws;
 import org.mule.runtime.extension.api.annotation.param.Connection;
 import org.mule.runtime.extension.api.annotation.param.Content;

--- a/src/main/java/com/marklogic/mule/extension/ReadPagingProvider.java
+++ b/src/main/java/com/marklogic/mule/extension/ReadPagingProvider.java
@@ -6,7 +6,6 @@ import com.marklogic.client.io.DocumentMetadataHandle;
 import com.marklogic.client.io.Format;
 import com.marklogic.client.io.InputStreamHandle;
 import com.marklogic.mule.extension.api.DocumentAttributes;
-import com.marklogic.mule.extension.api.ErrorType;
 import org.jetbrains.annotations.NotNull;
 import org.mule.runtime.api.metadata.MediaType;
 import org.mule.runtime.extension.api.exception.ModuleException;

--- a/src/main/java/com/marklogic/mule/extension/api/DocumentAttributes.java
+++ b/src/main/java/com/marklogic/mule/extension/api/DocumentAttributes.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.marklogic.client.io.DocumentMetadataHandle;
+import com.marklogic.mule.extension.ErrorType;
 import org.mule.runtime.extension.api.exception.ModuleException;
 import org.w3c.dom.Node;
 


### PR DESCRIPTION
Verified that they weren't in this package in the 1.x connector. Just trying to minimize the number of things in the "api" package. 