### PR TITLE
Rearranged packages and classes based on the MuleSoft checklist

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,9 +6,9 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.marklogic</groupId>
   <artifactId>marklogic-mule-connector</artifactId>
-  <version>2.0.0-SNAPSHOT</version>
+  <version>2.0.1-SNAPSHOT</version>
   <packaging>mule-extension</packaging>
-  <name>MarkLogic Connector for Mule</name>
+  <name>MarkLogic Connector for Mule 4</name>
 
   <parent>
     <groupId>org.mule.extensions</groupId>

--- a/src/main/java/com/marklogic/mule/connector/api/Operations.java
+++ b/src/main/java/com/marklogic/mule/connector/api/Operations.java
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.marklogic.mule.internal;
+package com.marklogic.mule.connector.api;
 
 import com.marklogic.client.DatabaseClient;
-import com.marklogic.mule.internal.error.provider.ExecuteErrorsProvider;
+import com.marklogic.mule.connector.internal.error.provider.ExecuteErrorsProvider;
 import org.mule.runtime.extension.api.annotation.error.Throws;
 import org.mule.runtime.extension.api.annotation.param.Connection;
 import org.mule.runtime.extension.api.annotation.param.Content;

--- a/src/main/java/com/marklogic/mule/connector/api/QueryParameters.java
+++ b/src/main/java/com/marklogic/mule/connector/api/QueryParameters.java
@@ -1,4 +1,4 @@
-package com.marklogic.mule.internal;
+package com.marklogic.mule.connector.api;
 
 import com.marklogic.client.DatabaseClient;
 import com.marklogic.client.document.DocumentManager;
@@ -6,8 +6,9 @@ import com.marklogic.client.io.Format;
 import com.marklogic.client.io.StringHandle;
 import com.marklogic.client.query.QueryDefinition;
 import com.marklogic.client.query.QueryManager;
-import com.marklogic.mule.internal.api.QueryFormat;
-import com.marklogic.mule.internal.api.QueryType;
+import com.marklogic.mule.connector.internal.Utilities;
+import com.marklogic.mule.connector.internal.provider.QueryFormat;
+import com.marklogic.mule.connector.internal.provider.QueryType;
 import org.mule.runtime.extension.api.annotation.param.NullSafe;
 import org.mule.runtime.extension.api.annotation.param.Optional;
 import org.mule.runtime.extension.api.annotation.param.Parameter;

--- a/src/main/java/com/marklogic/mule/connector/api/ReadPagingProvider.java
+++ b/src/main/java/com/marklogic/mule/connector/api/ReadPagingProvider.java
@@ -1,4 +1,4 @@
-package com.marklogic.mule.internal;
+package com.marklogic.mule.connector.api;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marklogic.client.DatabaseClient;
@@ -10,8 +10,9 @@ import com.marklogic.client.io.Format;
 import com.marklogic.client.io.InputStreamHandle;
 import com.marklogic.client.io.JacksonParserHandle;
 import com.marklogic.client.query.QueryDefinition;
-import com.marklogic.mule.internal.api.DocumentAttributes;
-import com.marklogic.mule.internal.error.ErrorType;
+import com.marklogic.mule.connector.internal.Utilities;
+import com.marklogic.mule.connector.internal.provider.DocumentAttributes;
+import com.marklogic.mule.connector.internal.error.ErrorType;
 import org.mule.runtime.api.metadata.MediaType;
 import org.mule.runtime.extension.api.exception.ModuleException;
 import org.mule.runtime.extension.api.runtime.operation.Result;

--- a/src/main/java/com/marklogic/mule/connector/api/WriteParameters.java
+++ b/src/main/java/com/marklogic/mule/connector/api/WriteParameters.java
@@ -1,4 +1,4 @@
-package com.marklogic.mule.internal;
+package com.marklogic.mule.connector.api;
 
 import com.marklogic.client.DatabaseClient;
 import com.marklogic.client.document.DocumentWriteSet;
@@ -6,7 +6,8 @@ import com.marklogic.client.document.ServerTransform;
 import com.marklogic.client.io.DocumentMetadataHandle;
 import com.marklogic.client.io.Format;
 import com.marklogic.client.io.InputStreamHandle;
-import com.marklogic.mule.internal.api.DocumentFormat;
+import com.marklogic.mule.connector.internal.Utilities;
+import com.marklogic.mule.connector.internal.provider.DocumentFormat;
 import org.mule.runtime.extension.api.annotation.param.Optional;
 import org.mule.runtime.extension.api.annotation.param.Parameter;
 import org.mule.runtime.extension.api.annotation.param.display.DisplayName;

--- a/src/main/java/com/marklogic/mule/connector/api/config/Configuration.java
+++ b/src/main/java/com/marklogic/mule/connector/api/config/Configuration.java
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.marklogic.mule.internal.config;
+package com.marklogic.mule.connector.api.config;
 
-import com.marklogic.mule.internal.Operations;
-import com.marklogic.mule.internal.connection.provider.ConnectionProvider;
+import com.marklogic.mule.connector.api.Operations;
+import com.marklogic.mule.connector.api.provider.ConnectionProvider;
 import org.mule.runtime.extension.api.annotation.connectivity.ConnectionProviders;
 import org.mule.runtime.extension.api.annotation.param.display.DisplayName;
 import org.mule.runtime.extension.api.annotation.param.display.Summary;

--- a/src/main/java/com/marklogic/mule/connector/api/extension/MarkLogicConnector.java
+++ b/src/main/java/com/marklogic/mule/connector/api/extension/MarkLogicConnector.java
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.marklogic.mule.internal.extension;
+package com.marklogic.mule.connector.api.extension;
 
-import com.marklogic.mule.internal.config.Configuration;
-import com.marklogic.mule.internal.error.ErrorType;
+import com.marklogic.mule.connector.api.config.Configuration;
+import com.marklogic.mule.connector.internal.error.ErrorType;
 import org.mule.runtime.api.meta.Category;
 import org.mule.runtime.extension.api.annotation.Configurations;
 import org.mule.runtime.extension.api.annotation.Extension;

--- a/src/main/java/com/marklogic/mule/connector/api/provider/ConnectionProvider.java
+++ b/src/main/java/com/marklogic/mule/connector/api/provider/ConnectionProvider.java
@@ -13,16 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.marklogic.mule.internal.connection.provider;
+package com.marklogic.mule.connector.api.provider;
 
 import com.marklogic.client.DatabaseClient;
 import com.marklogic.client.DatabaseClientBuilder;
 import com.marklogic.client.DatabaseClientFactory;
 import com.marklogic.client.impl.SSLUtil;
-import com.marklogic.mule.internal.error.ErrorType;
-import com.marklogic.mule.internal.api.AuthenticationType;
-import com.marklogic.mule.internal.api.ConnectionType;
-import com.marklogic.mule.internal.api.HostnameVerifier;
+import com.marklogic.mule.connector.internal.provider.AuthenticationType;
+import com.marklogic.mule.connector.internal.error.ErrorType;
+import com.marklogic.mule.connector.internal.provider.ConnectionType;
+import com.marklogic.mule.connector.internal.provider.HostnameVerifier;
 import org.mule.runtime.api.connection.CachedConnectionProvider;
 import org.mule.runtime.api.connection.ConnectionValidationResult;
 import org.mule.runtime.api.lifecycle.Initialisable;
@@ -132,7 +132,7 @@ public class ConnectionProvider implements CachedConnectionProvider<DatabaseClie
 
     @Parameter
     @DisplayName("Hostname Verifier")
-    @Placement(tab = "SSL/TLS")
+    @Placement(tab = SECURITY_TAB)
     @Summary("Specifies how a hostname is verified during SSL authentication. COMMON allows any level of subdomain " +
         "for SSL certificates with wildcard domains. STRICT only allows one subdomain level for SSL certificates with " +
         "wildcard domains. ANY disables hostname verification and is not recommended for production usage.")

--- a/src/main/java/com/marklogic/mule/connector/internal/Utilities.java
+++ b/src/main/java/com/marklogic/mule/connector/internal/Utilities.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.marklogic.mule.internal;
+package com.marklogic.mule.connector.internal;
 
 import com.marklogic.client.document.ServerTransform;
 

--- a/src/main/java/com/marklogic/mule/connector/internal/error/ErrorType.java
+++ b/src/main/java/com/marklogic/mule/connector/internal/error/ErrorType.java
@@ -1,4 +1,4 @@
-package com.marklogic.mule.internal.error;
+package com.marklogic.mule.connector.internal.error;
 
 import org.mule.runtime.extension.api.error.ErrorTypeDefinition;
 

--- a/src/main/java/com/marklogic/mule/connector/internal/error/provider/ExecuteErrorsProvider.java
+++ b/src/main/java/com/marklogic/mule/connector/internal/error/provider/ExecuteErrorsProvider.java
@@ -1,6 +1,6 @@
-package com.marklogic.mule.internal.error.provider;
+package com.marklogic.mule.connector.internal.error.provider;
 
-import com.marklogic.mule.internal.error.ErrorType;
+import com.marklogic.mule.connector.internal.error.ErrorType;
 import org.mule.runtime.extension.api.annotation.error.ErrorTypeProvider;
 import org.mule.runtime.extension.api.error.ErrorTypeDefinition;
 

--- a/src/main/java/com/marklogic/mule/connector/internal/provider/AuthenticationType.java
+++ b/src/main/java/com/marklogic/mule/connector/internal/provider/AuthenticationType.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.marklogic.mule.internal.api;
+package com.marklogic.mule.connector.internal.provider;
 
 public enum AuthenticationType {
 

--- a/src/main/java/com/marklogic/mule/connector/internal/provider/ConnectionType.java
+++ b/src/main/java/com/marklogic/mule/connector/internal/provider/ConnectionType.java
@@ -13,9 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.marklogic.mule.internal.api;
+package com.marklogic.mule.connector.internal.provider;
 
-public enum QueryFormat {
-    JSON,
-    XML;
+import com.marklogic.client.DatabaseClient;
+
+public enum ConnectionType {
+    DIRECT {
+        @Override
+        public DatabaseClient.ConnectionType getMarkLogicConnectionType() {
+            return DatabaseClient.ConnectionType.DIRECT;
+        }
+    },
+    GATEWAY {
+        @Override
+        public DatabaseClient.ConnectionType getMarkLogicConnectionType() {
+            return DatabaseClient.ConnectionType.GATEWAY;
+        }
+    };
+
+    public abstract DatabaseClient.ConnectionType getMarkLogicConnectionType();
 }

--- a/src/main/java/com/marklogic/mule/connector/internal/provider/DocumentAttributes.java
+++ b/src/main/java/com/marklogic/mule/connector/internal/provider/DocumentAttributes.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.marklogic.mule.internal.api;
+package com.marklogic.mule.connector.internal.provider;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.marklogic.client.io.DocumentMetadataHandle;
-import com.marklogic.mule.internal.error.ErrorType;
+import com.marklogic.mule.connector.internal.error.ErrorType;
 import org.mule.runtime.extension.api.exception.ModuleException;
 import org.w3c.dom.Node;
 

--- a/src/main/java/com/marklogic/mule/connector/internal/provider/DocumentFormat.java
+++ b/src/main/java/com/marklogic/mule/connector/internal/provider/DocumentFormat.java
@@ -1,4 +1,4 @@
-package com.marklogic.mule.internal.api;
+package com.marklogic.mule.connector.internal.provider;
 
 import com.marklogic.client.io.Format;
 

--- a/src/main/java/com/marklogic/mule/connector/internal/provider/HostnameVerifier.java
+++ b/src/main/java/com/marklogic/mule/connector/internal/provider/HostnameVerifier.java
@@ -1,4 +1,4 @@
-package com.marklogic.mule.internal.api;
+package com.marklogic.mule.connector.internal.provider;
 
 import com.marklogic.client.DatabaseClientFactory;
 

--- a/src/main/java/com/marklogic/mule/connector/internal/provider/QueryFormat.java
+++ b/src/main/java/com/marklogic/mule/connector/internal/provider/QueryFormat.java
@@ -13,23 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.marklogic.mule.internal.api;
+package com.marklogic.mule.connector.internal.provider;
 
-import com.marklogic.client.DatabaseClient;
-
-public enum ConnectionType {
-    DIRECT {
-        @Override
-        public DatabaseClient.ConnectionType getMarkLogicConnectionType() {
-            return DatabaseClient.ConnectionType.DIRECT;
-        }
-    },
-    GATEWAY {
-        @Override
-        public DatabaseClient.ConnectionType getMarkLogicConnectionType() {
-            return DatabaseClient.ConnectionType.GATEWAY;
-        }
-    };
-
-    public abstract DatabaseClient.ConnectionType getMarkLogicConnectionType();
+public enum QueryFormat {
+    JSON,
+    XML;
 }

--- a/src/main/java/com/marklogic/mule/connector/internal/provider/QueryType.java
+++ b/src/main/java/com/marklogic/mule/connector/internal/provider/QueryType.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.marklogic.mule.internal.api;
+package com.marklogic.mule.connector.internal.provider;
 
 public enum QueryType {
     STRING_QUERY,

--- a/src/test/java/com/marklogic/mule/extension/AbstractFlowTester.java
+++ b/src/test/java/com/marklogic/mule/extension/AbstractFlowTester.java
@@ -1,6 +1,6 @@
 package com.marklogic.mule.extension;
 
-import com.marklogic.mule.internal.api.DocumentAttributes;
+import com.marklogic.mule.connector.internal.provider.DocumentAttributes;
 import org.junit.Before;
 import org.mule.functional.junit4.MuleArtifactFunctionalTestCase;
 import org.mule.runtime.api.message.Message;

--- a/src/test/java/com/marklogic/mule/extension/DocumentData.java
+++ b/src/test/java/com/marklogic/mule/extension/DocumentData.java
@@ -1,6 +1,6 @@
 package com.marklogic.mule.extension;
 
-import com.marklogic.mule.internal.api.DocumentAttributes;
+import com.marklogic.mule.connector.internal.provider.DocumentAttributes;
 
 public class DocumentData {
 

--- a/src/test/java/com/marklogic/mule/extension/MetadataVerifier.java
+++ b/src/test/java/com/marklogic/mule/extension/MetadataVerifier.java
@@ -1,6 +1,6 @@
 package com.marklogic.mule.extension;
 
-import com.marklogic.mule.internal.api.DocumentAttributes;
+import com.marklogic.mule.connector.internal.provider.DocumentAttributes;
 import org.junit.Assert;
 
 import javax.xml.namespace.QName;

--- a/src/test/java/com/marklogic/mule/extension/SearchDocumentsWithMetadataTest.java
+++ b/src/test/java/com/marklogic/mule/extension/SearchDocumentsWithMetadataTest.java
@@ -1,6 +1,6 @@
 package com.marklogic.mule.extension;
 
-import com.marklogic.mule.internal.api.DocumentAttributes;
+import com.marklogic.mule.connector.internal.provider.DocumentAttributes;
 import org.junit.Test;
 
 import java.util.List;

--- a/src/test/java/com/marklogic/mule/extension/WriteDocumentTest.java
+++ b/src/test/java/com/marklogic/mule/extension/WriteDocumentTest.java
@@ -1,8 +1,7 @@
 package com.marklogic.mule.extension;
 
 
-import com.marklogic.mule.internal.api.DocumentAttributes;
-import org.junit.Ignore;
+import com.marklogic.mule.connector.internal.provider.DocumentAttributes;
 import org.junit.Test;
 
 import java.util.HashSet;


### PR DESCRIPTION
No real code changes here. Mostly just moving things around.
I'm not 100% certain this is the correct layout of packages and classes, but I'm confident it is closer.

Also:
Made a minor change to the POM
Changed the tab location for one connection parameter (Hostname Verifier).

This should cover all of the required changes for "Best Practices - Connector Interface", except for the single row which we intend to push back on (output schema).
