### PR TITLE
Remove exports of non-api classes from the api classes

### DIFF
--- a/src/main/java/com/marklogic/mule/connector/api/types/ConnectionType.java
+++ b/src/main/java/com/marklogic/mule/connector/api/types/ConnectionType.java
@@ -17,21 +17,7 @@
  */
 package com.marklogic.mule.connector.api.types;
 
-import com.marklogic.client.DatabaseClient;
-
 public enum ConnectionType {
-    DIRECT {
-        @Override
-        public DatabaseClient.ConnectionType getMarkLogicConnectionType() {
-            return DatabaseClient.ConnectionType.DIRECT;
-        }
-    },
-    GATEWAY {
-        @Override
-        public DatabaseClient.ConnectionType getMarkLogicConnectionType() {
-            return DatabaseClient.ConnectionType.GATEWAY;
-        }
-    };
-
-    public abstract DatabaseClient.ConnectionType getMarkLogicConnectionType();
+    DIRECT,
+    GATEWAY;
 }

--- a/src/main/java/com/marklogic/mule/connector/api/types/DocumentAttributes.java
+++ b/src/main/java/com/marklogic/mule/connector/api/types/DocumentAttributes.java
@@ -37,6 +37,7 @@ import java.io.InputStream;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -185,8 +186,16 @@ public class DocumentAttributes {
         return metadata.getQuality();
     }
 
-    public Map<String, Set<DocumentMetadataHandle.Capability>> getPermissions() {
-        return metadata.getPermissions();
+    public Map<String, Set<String>> getPermissions() {
+        Map<String, Set<String>> permissionsMap = new HashMap<>();
+        metadata.getPermissions().forEach((key, capabilitySet) -> {
+            Set<String> capabilities = new HashSet<>();
+            capabilitySet.forEach(capability ->
+                capabilities.add(capability.name())
+            );
+            permissionsMap.put(key, capabilities);
+        });
+        return permissionsMap;
     }
 
     public Map<QName, Object> getProperties() {

--- a/src/main/java/com/marklogic/mule/connector/api/types/DocumentFormat.java
+++ b/src/main/java/com/marklogic/mule/connector/api/types/DocumentFormat.java
@@ -17,44 +17,15 @@
  */
 package com.marklogic.mule.connector.api.types;
 
-import com.marklogic.client.io.Format;
-
 /**
  * Class exists solely to avoid warnings from Mule about the Java Client's Format class being used in an operation
  * but not being in a package with "api" or "internal" in its name.
  */
 public enum DocumentFormat {
 
-    BINARY {
-        @Override
-        public Format getFormat() {
-            return Format.BINARY;
-        }
-    },
-    JSON {
-        @Override
-        public Format getFormat() {
-            return Format.JSON;
-        }
-    },
-    TEXT {
-        @Override
-        public Format getFormat() {
-            return Format.TEXT;
-        }
-    },
-    XML {
-        @Override
-        public Format getFormat() {
-            return Format.XML;
-        }
-    },
-    UNKNOWN {
-        @Override
-        public Format getFormat() {
-            return Format.UNKNOWN;
-        }
-    };
-
-    public abstract Format getFormat();
+    BINARY,
+    JSON,
+    TEXT,
+    XML,
+    UNKNOWN;
 }

--- a/src/main/java/com/marklogic/mule/connector/api/types/HostnameVerifier.java
+++ b/src/main/java/com/marklogic/mule/connector/api/types/HostnameVerifier.java
@@ -17,34 +17,13 @@
  */
 package com.marklogic.mule.connector.api.types;
 
-import com.marklogic.client.DatabaseClientFactory;
-
 /**
  * Mirrors the Java Client's {@code SSLHostnameVerifier} class; this exists solely to avoid breaking changes if the
  * Java Client class were to change.
  */
 public enum HostnameVerifier {
 
-    ANY {
-        @Override
-        public DatabaseClientFactory.SSLHostnameVerifier getSslHostnameVerifier() {
-            return DatabaseClientFactory.SSLHostnameVerifier.ANY;
-        }
-    },
-
-    COMMON {
-        @Override
-        public DatabaseClientFactory.SSLHostnameVerifier getSslHostnameVerifier() {
-            return DatabaseClientFactory.SSLHostnameVerifier.COMMON;
-        }
-    },
-
-    STRICT {
-        @Override
-        public DatabaseClientFactory.SSLHostnameVerifier getSslHostnameVerifier() {
-            return DatabaseClientFactory.SSLHostnameVerifier.STRICT;
-        }
-    };
-
-    public abstract DatabaseClientFactory.SSLHostnameVerifier getSslHostnameVerifier();
+    ANY,
+    COMMON,
+    STRICT;
 }

--- a/src/main/java/com/marklogic/mule/connector/internal/connection/provider/ConnectionProvider.java
+++ b/src/main/java/com/marklogic/mule/connector/internal/connection/provider/ConnectionProvider.java
@@ -149,7 +149,7 @@ public class ConnectionProvider implements CachedConnectionProvider<DatabaseClie
             .withBasePath(basePath)
             .withDatabase(database)
             .withAuthType(authenticationType.name())
-            .withConnectionType(connectionType.getMarkLogicConnectionType())
+            .withConnectionType(DatabaseClient.ConnectionType.valueOf(connectionType.name()))
             .withUsername(username)
             .withPassword(password)
             .withCloudApiKey(cloudApiKey)
@@ -202,7 +202,18 @@ public class ConnectionProvider implements CachedConnectionProvider<DatabaseClie
         );
 
         if (hostnameVerifier != null) {
-            builder.withSSLHostnameVerifier(hostnameVerifier.getSslHostnameVerifier());
+            switch (hostnameVerifier) {
+                case COMMON:
+                    builder.withSSLHostnameVerifier(DatabaseClientFactory.SSLHostnameVerifier.COMMON);
+                    break;
+                case STRICT:
+                    builder.withSSLHostnameVerifier(DatabaseClientFactory.SSLHostnameVerifier.STRICT);
+                    break;
+                case ANY:
+                default:
+                    builder.withSSLHostnameVerifier(DatabaseClientFactory.SSLHostnameVerifier.ANY);
+                    break;
+            }
         }
     }
 

--- a/src/main/java/com/marklogic/mule/connector/internal/operation/WriteParameters.java
+++ b/src/main/java/com/marklogic/mule/connector/internal/operation/WriteParameters.java
@@ -117,7 +117,7 @@ public class WriteParameters {
         for (InputStream inputStream : contents) {
             writeSet.add(makeUri(), metadata,
                 new InputStreamHandle(inputStream)
-                    .withFormat(documentFormat != null ? documentFormat.getFormat() : Format.UNKNOWN));
+                    .withFormat(documentFormat != null ? Format.valueOf(documentFormat.name()) : Format.UNKNOWN));
         }
 
         final ServerTransform serverTransform = Utilities.hasText(transform) ?
@@ -126,7 +126,7 @@ public class WriteParameters {
 
         try {
             if (Utilities.hasText(temporalCollection)) {
-                if (documentFormat != null && Format.XML.equals(documentFormat.getFormat())) {
+                if (documentFormat != null && Format.XML.equals(Format.valueOf(documentFormat.name()))) {
                     databaseClient.newXMLDocumentManager().write(writeSet, serverTransform, null, temporalCollection);
                 } else {
                     databaseClient.newJSONDocumentManager().write(writeSet, serverTransform, null, temporalCollection);


### PR DESCRIPTION
The purpose of this is to remove all method return types that return classes that are not included in the API.